### PR TITLE
New structure with several figures

### DIFF
--- a/displayTabs.py
+++ b/displayTabs.py
@@ -1,7 +1,7 @@
 
-    ############
-    # PACKAGES #
-    ############
+############
+# PACKAGES #
+############
 
 # Tkinter
 import tkinter
@@ -9,11 +9,26 @@ from tkinter import ttk
 
 # Matplotlib
 from matplotlib.backends.backend_tkagg import (FigureCanvasTkAgg, NavigationToolbar2Tk)
-from matplotlib.backend_bases import key_press_handler
 from matplotlib.figure import Figure
 
 # Numpy
 import numpy as np
+
+
+
+    #############
+    # VARIABLES #
+    #############
+
+different_figures = []
+different_frames = []
+tabs_number = 3
+x_data1 = [1, 2, 3]
+y_data1 = [1, 2, 3]
+x_data2 = [1, 2, 3, 4, 5, 6]
+y_data2 = [1, 2, 3, 4, 5, 6]
+x_data3 = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+y_data3 = [1, 2, 3, 4, 5, 6, 7, 8, 9]
 
 
 
@@ -29,8 +44,8 @@ def _quit() :
 
     # Prevent fatal Python Error: PyEval_RestoreThread: NULL tstate              
     root.destroy() 
-         
-        
+                    
+
 
     ################
     # MAIN PROGRAM #
@@ -40,39 +55,45 @@ def _quit() :
 root = tkinter.Tk()
 root.wm_title("Embedding in Tk")
 
-# Creation of the notebook
-my_notebook = ttk.Notebook(root)
-my_notebook.pack()
-
-# Creation of the frames
-frame1 = tkinter.LabelFrame(root, padx=5, pady=5, width=500, height=500)
-frame1.pack()
-frame2 = tkinter.LabelFrame(root, padx=5, pady=5, width=500, height=500)
-frame2.pack()
-# You can add more if you want
-
-# Implementation of the frames in the notebook
-my_notebook.add(frame1, text="first tab")
-my_notebook.add(frame2, text="second tab")
-
 # Creation of the window close button
 button = tkinter.Button(master=root, text="Quit", command=_quit)
 button.pack(side=tkinter.BOTTOM)
 
-# Creation of the matplotlib figure
-fig = Figure(figsize=(5, 4), dpi=100)
-t = np.arange(0, 3, .01)
-fig.add_subplot(111).plot(t, 2 * np.sin(2 * np.pi * t))
+# Creation of the notebook
+my_notebook = ttk.Notebook(root)
+my_notebook.pack()
 
-# Implementation of the figure in the Tkinter window
-canvas = FigureCanvasTkAgg(fig, master=frame1)  # A tk.DrawingArea.
-canvas.draw()
-canvas.get_tk_widget().pack(side=tkinter.TOP, fill=tkinter.BOTH, expand=1)
+# Creation of all the frames (depends on the number of tabs)
+for i in range(tabs_number) :
+    
+    # Creation of the frame 
+    different_frames.append(tkinter.LabelFrame(root, padx=5, pady=5, width=500, height=500))
+    different_frames[i].pack()
+    
+    # add the frame in the notebook, linking it to a specific tab
+    my_notebook.add(different_frames[i], text='tab %d' % (i+1))
 
-# Implementation of the toolbar of the figure
-toolbar = NavigationToolbar2Tk(canvas, root)
-toolbar.update()
-canvas.get_tk_widget().pack(side=tkinter.TOP, fill=tkinter.BOTH, expand=1)
+# Creation of the matplotlib figures
+for i in range(tabs_number) :
+    different_figures.append(Figure(figsize=(5, 4), dpi=100))
+
+# Customization of the figures (can be automated during the previous figure creation loop)
+different_figures[0].add_subplot(211).plot(x_data1, y_data1) # First tab figure
+different_figures[1].add_subplot(211).plot(x_data2, y_data2) # Second tab figure
+different_figures[2].add_subplot(211).plot(x_data3, y_data3) # Third tab figure
+
+# Implementation of the figures in their respective frames
+for i in range(tabs_number) :
+
+    # Implementation of the figure in the frame
+    canvas = FigureCanvasTkAgg(different_figures[i], master=different_frames[i])  # A tk.DrawingArea.
+    canvas.draw()
+    canvas.get_tk_widget().pack(side=tkinter.TOP, fill=tkinter.BOTH, expand=1)
+
+    # Implementation of the toolbar of the figure
+    toolbar = NavigationToolbar2Tk(canvas, different_frames[i])
+    toolbar.update()
+    canvas.get_tk_widget().pack(side=tkinter.TOP, fill=tkinter.BOTH, expand=1)
 
 # Mainloop of the Tkinter window
 tkinter.mainloop()


### PR DESCRIPTION
I abandoned the idea of displaying subplots of the same figure within several Tkinter tabs. Indeed subplots are interpreted as lists and the widget linking Matplotlib to Tkinter does not interpret these lists as separate figures.
So I decided to display one figure per tab and automated the program so that everything depends only on a variable determining the number of Tkinter tabs.
All the frames (specific to each tab) and all the figures are stored in Python lists and are therefore easily joinable within loops.
I also took the opportunity to remove unnecessary imports (I had left the keyboard recognition package for example...)